### PR TITLE
Update change log for 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,7 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 <a id='changelog-0.1.1'></a>
 ## 0.1.1 (2024-09-23)
 
-### Bug fixes
-
-- Make canonical name of client 'rubin.nublado.client'
+This release contained no user-visible changes.
 
 <a id='changelog-0.1.0'></a>
 ## 0.1.0 (2024-09-23)


### PR DESCRIPTION
This release had no user-visible changes, just some changes to how dependencies were named that didn't affect what was installed, so note that in the change log instead.